### PR TITLE
NLR annotator text output is already zero based, fixes bed conversion

### DIFF
--- a/modules/smrtrenseq.nf
+++ b/modules/smrtrenseq.nf
@@ -230,7 +230,7 @@ process NLR2Bed {
         outfile_writer = csv.writer(outfile, delimiter='\t', lineterminator=os.linesep)
 
         for row in infile_reader:
-            outfile_writer.writerow([row[0], str(int(row[3]) - 1), row[4], row[1], 0, row[5]])
+            outfile_writer.writerow([row[0], row[3], row[4], row[1], 0, row[5]])
     """
 }
 


### PR DESCRIPTION
NLR Annotator output was treated as 1-based when creating the bed file. It is in fact 0-based and so there is an error when creating bed files. This resolves that issue.