### PR TITLE
Simplify dRenSeq samtools parsing

### DIFF
--- a/modules/drenseq.nf
+++ b/modules/drenseq.nf
@@ -113,7 +113,6 @@ process ParseAlignment {
     tuple val(sample), path('aligned.bam.bai')
     script:
     """
-    samtools view $sam -b -o aligned_unsorted.bam -@ $task.cpus
     samtools sort -l 9 $sam -o aligned.bam -@ $task.cpus
     samtools index aligned.bam aligned.bam.bai -@ $task.cpus
     """


### PR DESCRIPTION
Process ParseAlignment was converting from sam to bam twice. This removes the redundancy